### PR TITLE
Cookbook now uses the Perl license

### DIFF
--- a/doc/Inline/C/Cookbook.swim
+++ b/doc/Inline/C/Cookbook.swim
@@ -1402,4 +1402,7 @@ Copyright 2000-2014. Ingy döt Net.
 
 Copyright 2008, 2010-2014. Sisyphus.
 
+This program is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself.
+
 See http://www.perl.com/perl/misc/Artistic.html


### PR DESCRIPTION
Signed-off-by: Petr Šabata contyk@redhat.com
