### PR TITLE
make cleanup() more robust against bogus input and unexpected file system layout

### DIFF
--- a/lib/Inline/C.pm
+++ b/lib/Inline/C.pm
@@ -903,12 +903,9 @@ sub cleanup {
             $modpname
         );
         my $autodir = File::Spec->catdir($install_lib,'auto',$modpname);
-        unlink (
-            File::Spec->catfile($autodir,'.packlist'),
-            File::Spec->catfile($autodir,"$modfname.bs"),
-            File::Spec->catfile($autodir,"$modfname.exp"), #MSWin32
-            File::Spec->catfile($autodir,"$modfname.lib"), #MSWin32
-        );
+        my @files = ( ".packlist", map "$modfname.$_", qw( bs exp lib ) );
+        my @paths = grep { -e } map { File::Spec->catfile($autodir,$_) } @files;
+        unlink($_) || die "Can't delete file $_: $!" for @paths;
     }
 }
 

--- a/lib/Inline/C.pm
+++ b/lib/Inline/C.pm
@@ -905,9 +905,9 @@ sub cleanup {
         my $autodir = File::Spec->catdir($install_lib,'auto',$modpname);
         unlink (
             File::Spec->catfile($autodir,'.packlist'),
-            File::Spec->catfile($autodir,'$modfname.bs'),
-            File::Spec->catfile($autodir,'$modfname.exp'), #MSWin32
-            File::Spec->catfile($autodir,'$modfname.lib'), #MSWin32
+            File::Spec->catfile($autodir,"$modfname.bs"),
+            File::Spec->catfile($autodir,"$modfname.exp"), #MSWin32
+            File::Spec->catfile($autodir,"$modfname.lib"), #MSWin32
         );
     }
 }


### PR DESCRIPTION
* reenable bs/exp/lib deletion on cleanup

Since before 0.54 these strings were defined with single quotes, stopping the mod name from interpolating, and thus also the deletion of those files.

* add sanity checks to cleanup deletion

Previously the cleanup phase just blindly tried to delete the files and silently gave up when it couldn't find them. With this change it'll check whether they exist and then delete them or die trying.

I suspect it might also be useful to check whether $autodir is a directory and die if not, and to assume a .packlist is generated and die if it can't be found, but that's up to you guys.

related to #36
related to ingydotnet/inline-pm#51