### PR TITLE
Add CPPFLAGS argument for C preprocessor directives.

### DIFF
--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -138,6 +138,14 @@ space, followed by the specified value:
 
     use Inline C => config => ccflagsex => "-DXTRA -DTOO";
 
+=item C<cppflags>
+
+Specify preprocessor flags.
+Passed to 'cpp' C preprocessor by Preprocess() in Inline::Filters.
+
+    use Inline C => <<'END' => CPPFLAGS => ' -DPREPROCESSOR_DEFINE'      => FILTERS => 'Preprocess';
+    use Inline C => <<'END' => CPPFLAGS => ' -DPREPROCESSOR_DEFINE=4321' => FILTERS => 'Preprocess';
+
 =item C<filters>
 
 Allows you to specify a list of source code filters. If more than one is

--- a/lib/Inline/C.pm
+++ b/lib/Inline/C.pm
@@ -1,6 +1,6 @@
 use strict; use warnings;
 package Inline::C;
-our $VERSION = '0.75';
+our $VERSION = '0.76';
 
 use Inline 0.56;
 use Config;
@@ -239,6 +239,11 @@ END
             $o->{CONFIG}{PROTOTYPE} = $value;
             next;
         }
+        if ($key eq 'CPPFLAGS') {
+            # C preprocessor flags, used by Inline::Filters::Preprocess()
+            next;
+        }
+        
         my $class = ref $o; # handles subclasses correctly.
         croak "'$key' is not a valid config option for $class\n";
     }

--- a/test/29cppflags.t
+++ b/test/29cppflags.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use diagnostics;
+use lib -e 't' ? 't' : 'test';
+use TestInlineSetup;
+use Config;
+use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
+
+print "1..1\n";
+
+use Inline C => Config =>
+    #BUILD_NOISY => 1,
+    FORCE_BUILD => 1,
+    CCFLAGS     => $Config{ccflags};
+
+# DEV NOTE: do not actually test CPPFLAGS effect on Inline::Filters here,
+# only test the ability to pass CPPFLAGS argument through Inline::C;
+# see t/Preprocess_cppflags.t in Inline::Filters for real tests
+use Inline C => <<'END' => CPPFLAGS => ' -DPREPROCESSOR_DEFINE';
+int foo() { return 4321; }
+END
+
+my $foo_retval = foo();
+
+if ( $foo_retval == 4321 ) {
+    print "ok 1\n";
+}
+else {
+    warn "\n Expected: 4321\n Got: $foo_retval\n";
+    print "not ok 1\n";
+}


### PR DESCRIPTION
When combined with the pending Inline::Filters v0.17 code, this pull request solves Inline::C issue #42 

https://github.com/perl11/Inline-Filters/pull/1