### PR TITLE
use FindBin in tests

### DIFF
--- a/test/01syntax.t
+++ b/test/01syntax.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/02config.t
+++ b/test/02config.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/03typemap.t
+++ b/test/03typemap.t
@@ -1,11 +1,16 @@
 use strict; use warnings; use diagnostics;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+use lib $Bin;
+my $t;
+BEGIN {
+    $t = $Bin;
+}
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 
 use Inline C => DATA =>
-  TYPEMAPS => File::Spec->catfile(File::Spec->curdir(), $t, 'typemap');
+  TYPEMAPS => File::Spec->catfile($t, 'typemap');
 
 is(int((add_em_up(1.2, 3.4) + 0.001) * 10), 46);
 

--- a/test/04perlapi.t
+++ b/test/04perlapi.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/05xsmode.t
+++ b/test/05xsmode.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/06parseregexp.t
+++ b/test/06parseregexp.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/07typemap_multi.t
+++ b/test/07typemap_multi.t
@@ -1,5 +1,7 @@
 use strict; use warnings; use diagnostics;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+use lib $Bin;
+my $t = $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/08taint.t
+++ b/test/08taint.t
@@ -12,7 +12,15 @@ BEGIN {
 }
 
 use warnings; use strict;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+my $bin;
+BEGIN {
+    # untaint
+    ($bin) = $Bin =~ m/(.*)/;
+}
+my $t = $bin;
+use lib $bin;
+
 use Test::More tests => 10;
 use Test::Warn;
 use TestInlineSetup;
@@ -30,15 +38,13 @@ warnings_like {require_taint_2()} [qr/$w1/, qr/$w2/, qr/$w1/, qr/$w3/], 'warn_te
 warnings_like {require_taint_3()} [qr/$w1/, qr/$w2/, qr/$w1/, qr/$w3/, qr/$w1/, qr/$w2/, qr/$w1/, qr/$w3/], 'warn_test 3';
 
 sub require_taint_1 {
-    require "./$t/08taint_1.p";
+    require "$t/08taint_1.p";
 }
 
 sub require_taint_2 {
-    my $t = -d 'test' ? 'test' : 't';
-    require "./$t/08taint_2.p";
+    require "$t/08taint_2.p";
 }
 
 sub require_taint_3 {
-    my $t = -d 'test' ? 'test' : 't';
-    require "./$t/08taint_3.p";
+    require "$t/08taint_3.p";
 }

--- a/test/09parser.t
+++ b/test/09parser.t
@@ -27,7 +27,8 @@ BEGIN {
 };
 
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 

--- a/test/10callback.t
+++ b/test/10callback.t
@@ -3,7 +3,9 @@
 # This test script plagiarises the perlcall documentation.
 
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
+my $t = $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/11default_readonly.t
+++ b/test/11default_readonly.t
@@ -2,7 +2,8 @@
 # Thanks Marty O'Brien.
 
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 

--- a/test/14void_arg.t
+++ b/test/14void_arg.t
@@ -1,5 +1,6 @@
 use strict; use warnings;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use diagnostics;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/14void_arg_PRD.t
+++ b/test/14void_arg_PRD.t
@@ -2,7 +2,8 @@
 # Tests 4 onwards are not expected to pass - so we make them TODO.
 
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use Test::More;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/15ccflags.t
+++ b/test/15ccflags.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Config;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/16ccflagsex.t
+++ b/test/16ccflagsex.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Config;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/17prehead.t
+++ b/test/17prehead.t
@@ -1,5 +1,10 @@
 use strict; use warnings; use diagnostics;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+use lib $Bin;
+my$t;
+BEGIN {
+    $t = $Bin;
+}
 use TestInlineSetup;
 use Config;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/19INC.t
+++ b/test/19INC.t
@@ -1,13 +1,17 @@
 use strict; use warnings; use diagnostics;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+use lib $Bin;
+my $t;
+BEGIN {
+    $t = $Bin;
+}
 use Cwd;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 
 BEGIN {
-  my $cwd = Cwd::getcwd();
-  my $incdir1 = $cwd . "/$t/foo/";
-  my $incdir2 = $cwd . "/$t/bar/";
+  my $incdir1 = "$t/foo/";
+  my $incdir2 = "$t/bar/";
   $main::includes = "-I$incdir1  -I$incdir2";
 };
 

--- a/test/20eval.t
+++ b/test/20eval.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 

--- a/test/21read_DATA.t
+++ b/test/21read_DATA.t
@@ -2,7 +2,8 @@
 # The bug existed up to and including Inline-0.52.
 
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 

--- a/test/22read_DATA_2.t
+++ b/test/22read_DATA_2.t
@@ -2,7 +2,8 @@
 # The bug existed up to and including Inline-0.52.
 
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 

--- a/test/24prefix.t
+++ b/test/24prefix.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Config;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;

--- a/test/25proto.t
+++ b/test/25proto.t
@@ -1,5 +1,7 @@
 use strict; use warnings;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+use lib $Bin;
+my $t = $Bin;
 use TestInlineSetup;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;
 

--- a/test/26fork.t
+++ b/test/26fork.t
@@ -1,5 +1,6 @@
 use strict; use warnings;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Test::More;
 use Config;

--- a/test/27inline_maker.t
+++ b/test/27inline_maker.t
@@ -1,5 +1,6 @@
 use strict; use warnings; use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Test::More;
 use Config;

--- a/test/28autowrap.t
+++ b/test/28autowrap.t
@@ -1,5 +1,7 @@
 use strict; use warnings; use diagnostics;
-my $t; use lib ($t = -e 't' ? 't' : 'test');
+use FindBin '$Bin';
+use lib $Bin;
+my $t = $Bin;
 use TestInlineSetup;
 use Inline config => directory => $TestInlineSetup::DIR;
 use Test::More;

--- a/test/30cppflags.t
+++ b/test/30cppflags.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 use diagnostics;
-use lib -e 't' ? 't' : 'test';
+use FindBin '$Bin';
+use lib $Bin;
 use TestInlineSetup;
 use Config;
 use Inline Config => DIRECTORY => $TestInlineSetup::DIR;


### PR DESCRIPTION
perl 5.26 won't have . in @INC anymore.

See issue #61

