### PR TITLE
test: Adjust excpected number of lines in log to Inline-0.82_001

### DIFF
--- a/test/09parser.t
+++ b/test/09parser.t
@@ -177,7 +177,9 @@ is ($res, $prod, "Returned product");
 
 chomp (my @p = do { local @ARGV = "$TestInlineSetup::DIR/parser_id"; <> });
 
-is (scalar @p, 21, "Match number of lines in log");
+my $expected_log_lines = 13;
+$expected_log_lines += 8 if $Inline::VERSION < 0.82_001;
+is (scalar @p, $expected_log_lines, "Match number of lines in log");
 
 TODO: {
 local $TODO = 'Until pegex is default';


### PR DESCRIPTION
This Inline change:

    commit 13fd62a675c9de3c1fdb734898a689155647c5b1 (HEAD, origin/config-accum)
    Author: Ed J <mohawk2@users.noreply.github.com>
    Date:   Tue Apr 2 18:37:12 2019 +0100

	merge per-language config, not overwrite

available in Inline-0.82_001 changed log file content and Inline-C 09parser.t
test started to fail. This patch adjust the test to pass with old and new Inline.

https://github.com/ingydotnet/inline-c-pm/issues/88