### PR TITLE
make correct PERL5LIB to pass on including -I flags

### DIFF
--- a/Meta
+++ b/Meta
@@ -28,7 +28,7 @@ devel:
 requires:
   perl: 5.8.1
   File::Spec: 0.8
-  Inline: 0.83
+  Inline: 0.86
   Parse::RecDescent: 1.967009
   Pegex: 0.66
   ExtUtils::MakeMaker: 7.00

--- a/lib/Inline/C.pm
+++ b/lib/Inline/C.pm
@@ -896,7 +896,8 @@ sub makefile_pl {
         or ($perl = $^X)
         or croak "Can't locate your perl binary";
     $perl = qq{"$perl"} if $perl =~ m/\s/;
-    $o->system_call("$perl Makefile.PL", 'out.Makefile_PL');
+    my @_inc = map qq{"-I$_"}, $o->derive_minus_I;
+    $o->system_call("$perl @_inc Makefile.PL", 'out.Makefile_PL');
     $o->fix_make;
 }
 sub make {


### PR DESCRIPTION
Doing this properly will eliminate a class of failures in (among others) `Inline::Pdlapp` deps, where the smoker has the prereq (`Inline::Pdlapp`) in a local-lib, which the existing filter doesn't find.

I have made this be a method call. I am also putting the same logic (and in fact code) in `Inline`. If that is accepted and released, it could remain a method call, but deleting the local implementation, with an updated dep.