### PR TITLE
Use File::Path for creating temporary directories in the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
   File::Copy::Recursive
   File::Path
   File::Spec~0.8
+  File::Temp~0.19
   Inline~0.86
   Parse::RecDescent~1.967009
   Pegex~0.66

--- a/Meta
+++ b/Meta
@@ -42,6 +42,7 @@ test:
     autodie: 0
     File::Copy::Recursive: 0
     File::Path: 0
+    File::Temp: 0.19
     Test::More: 0.88
     Test::Warn: 0.23
     version: 0.77

--- a/test/18quote_space.t
+++ b/test/18quote_space.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Cwd;
+use File::Temp 0.19;
 
 require Inline::C;
 
@@ -126,8 +126,8 @@ else {
 delete $ENV{NO_INSANE_DIRNAMES};
 
 my $have_file_path;
-my $newdir = Cwd::getcwd();
-$newdir .= '/foo -I/';
+my $tempdir = File::Temp->newdir();
+my $newdir = $tempdir . '/foo -I/';
 
 eval {require File::Path;};
 if ($@) {
@@ -159,9 +159,3 @@ else {
     warn "\n\$\@: $@\n";
     print "not ok 10\n";
 }
-
-
-END {
-    File::Path::rmtree($newdir) if $have_file_path;
-    warn "Failed to remove $newdir" if -d $newdir;
-};

--- a/test/TestInlineSetup.pm
+++ b/test/TestInlineSetup.pm
@@ -1,8 +1,8 @@
 use strict; use warnings; use diagnostics;
 package TestInlineSetup;
 
-use File::Path;
 use File::Spec;
+use File::Temp 0.19;
 use constant IS_WIN32 => $^O eq 'MSWin32' ;
 
 sub import {
@@ -22,14 +22,8 @@ BEGIN {
 
 our $DIR;
 BEGIN {
-    ($_, $DIR) = caller(2);
-    $DIR =~ s/.*?(\w+)\.t$/$1/ or die;
-    $DIR = "_Inline_$DIR.$$";
-    rmtree($DIR) if -d $DIR;
-    mkdir($DIR) or die "$DIR: $!\n";
+    $DIR = File::Temp->newdir();
 }
-my $absdir = File::Spec->rel2abs($DIR);
-($absdir) = $absdir =~ /(.*)/; # untaint
 
 my $startpid = $$;
 END {
@@ -54,7 +48,6 @@ END {
         }
       }
     }
-    rmtree($absdir);
   }
 }
 


### PR DESCRIPTION
The tests used to create a temporary tree under a working directory.
But that does not work if that location is read-only:

$ perl t/01syntax.t
Uncaught exception from user code:
        _Inline_01syntax.17483: Permission denied
        BEGIN failed--compilation aborted at /usr/libexec/perl-Inline-C/t/TestInlineSetup.pm line 30.
        Compilation failed in require at t/01syntax.t line 6.
        BEGIN failed--compilation aborted at t/01syntax.t line 6.

Also the code tried hard to pick up a unique name to allow testing in
parallel. And then cleaning up when exiting.

This patch replaced that code with File::Temp. Not only it replaces
complex code, it also enables testing from a read only location
because File::Test utilizes a system-wide temporary path.

I cannot test it on Win32 platform. But I believe it should correctly
work there because the cleanup is performed when the File::Temp object
goes out of scope which should be after END block.